### PR TITLE
shorten the CPU brand output, fixes #2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "omnifetch"
-version = "0.1.1"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnifetch"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 description = "Print information about an OmniOS machine."
 readme = "README.md"

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,13 +49,49 @@ fn get_kernel() -> Result<String> {
 }
 
 fn get_cpu() -> Result<String> {
+    // strings to remove from the CPU brand name
+    // borrowed heavily from neofetch
+    let strings_to_remove = [
+        "(TM)",
+        "(tm)",
+        "(R)",
+        "(r)",
+        "CPU",
+        "Processor",
+        "Dual-Core",
+        "Quad-Core",
+        "Six-Core",
+        "Eight-Core",
+        " Compute Cores",
+        "Core / ",
+        "(\"AuthenticAMD\"*)",
+        "with Radeon",
+        "Graphics",
+        ", altivec supported",
+        "FPU",
+        "Chip Revision",
+        "Technologies, Inc",
+        "Core2/Core 2",
+    ];
+
     let output = run! { "kstat -p cpu_info:::brand" }?;
     let lines = output.lines();
 
     let mut counts = HashMap::new();
     for line in lines {
         let spl: Vec<_> = line.split('\t').collect();
-        let brand = spl[1];
+        let mut brand = spl[1].to_string();
+
+        // remove extra strings
+        for s in strings_to_remove {
+            brand = brand.replace(s, "");
+        }
+
+        // remove any extraneous spaces
+        let parts: Vec<_> = brand.split_whitespace().collect();
+        let brand = parts.join(" ");
+
+        // frequency count them
         *counts.entry(brand).or_insert(0) += 1;
     }
 


### PR DESCRIPTION
These strings lifted from:

https://github.com/dylanaraps/neofetch/blob/ccd5d9f52609bbdcd5d8fa78c4fdb0f12954125f/neofetch#L2368-L2384

---

From the example in issue #2 this changes the string from:

```
Intel(r) Xeon(r) CPU E5-2650 v3 @ 2.30GHz
```

to:

```
Intel Xeon E5-2650 v3 @ 2.30GHz
```